### PR TITLE
Use a unique user key for the context

### DIFF
--- a/src/js/ldClient.js
+++ b/src/js/ldClient.js
@@ -3,6 +3,22 @@ import * as LDClient from "./ldclient.min.js";
 let ldClientInstance = null;
 
 /**
+ * Generates a stable, randomized user key per session.
+ * Uses localStorage to persist across page refreshes.
+ */
+function generateUserKey() {
+  if (typeof window !== "undefined") {
+    let userKey = localStorage.getItem("ld-user-key");
+    if (!userKey) {
+      userKey = `user-${Math.random().toString(36).substr(2, 9)}`;
+      localStorage.setItem("ld-user-key", userKey);
+    }
+    return userKey;
+  }
+  return `user-${Math.random().toString(36).substr(2, 9)}`;
+}
+
+/**
  * Initializes LaunchDarkly with user location context.
  * @param {string} location - User location (e.g., "Europe", "California").
  */
@@ -21,9 +37,11 @@ export function getLDClient(location = "default") {
     return null;
   }
 
+  const userKey = generateUserKey();
+
   const context = {
     kind: "user",
-    key: `user-${location}`,
+    key: userKey,
     location: location,
   };
 
@@ -43,7 +61,7 @@ export function getLDClient(location = "default") {
  * @param {string} newLocation - New selected region.
  */
 export function updateLDContext(newLocation) {
-  console.log('updateLDContext: ' + newLocation);
+  console.log("updateLDContext: " + newLocation);
   if (!ldClientInstance) {
     console.warn("⚠️ LaunchDarkly has not been initialized yet.");
     return;

--- a/src/ledgr-vs-assetwise.html
+++ b/src/ledgr-vs-assetwise.html
@@ -45,7 +45,7 @@
           <strong>Ledgr</strong> for reliability, flexibility, and future-proof
           innovation.
         </p>
-        <a href="#comparison" role="button" class="contrast" id="comparison_btn">Compare Now</a>
+        <a href="#comparison" role="button" class="contrast" id="comparison_btn">Signup Today</a>
       </div>
       <!-- Hero Image (Placeholder) -->
       <img


### PR DESCRIPTION
Moves the user context from a temporary `user-[LOCATION]` to an actual unique identifier based on setting an ID in local storage.